### PR TITLE
[Thibaud B.] Electron challenge

### DIFF
--- a/electron-1/main.js
+++ b/electron-1/main.js
@@ -1,5 +1,6 @@
+const path = require('path');
 // Modules to control application life and create native browser window
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, ipcMain } = require('electron');
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -11,7 +12,7 @@ function createWindow() {
     width: 800,
     height: 600,
     webPreferences: {
-
+      preload: path.join(__dirname, 'preload.js'),
       // ------
       // You are not allowed to change the value
       // of this 3 flags
@@ -57,3 +58,11 @@ app.on('activate', function () {
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.
+
+ipcMain.on('name-message', (event, _arg) => {
+  event.sender.send('name-reply', app.getName());
+});
+
+ipcMain.on('version-message', (event, _arg) => {
+  event.sender.send('version-reply', app.getVersion());
+});

--- a/electron-1/preload.js
+++ b/electron-1/preload.js
@@ -1,0 +1,30 @@
+const { ipcRenderer } = require('electron');
+
+window.bx = {
+  /**
+   * Returns a promise resolving to the actual name of this electron application.
+   * @see https://github.com/electron/electron/blob/master/docs/api/app.md#appgetname
+   */
+  getName() {
+    // Value should come from `electron.app.getName()`
+    return new Promise((resolve) => {
+      ipcRenderer.send('name-message');
+      ipcRenderer.on('name-reply', (event, arg) => {
+        resolve(arg)
+      });
+    });
+  },
+  /**
+   * Returns a promise resolving to the actual version of this electron application.
+   * @see https://github.com/electron/electron/blob/master/docs/api/app.md#appgetversion
+   */
+  getVersion() {
+    // Value should come from `electron.app.getVersion()`
+    return new Promise((resolve) => {
+      ipcRenderer.send('version-message');
+      ipcRenderer.on('version-reply', (event, arg) => {
+        resolve(arg)
+      });
+    });
+  },
+}


### PR DESCRIPTION
Electron challenge made in 1h30.

## Test instructions and expectations

1. Start the app with `npm start` at root directory.
2. The app name and version (from package.json) should be filled in expected spans (`#bx-name` and `#bx-version`) and visible in app window.

## How does it work?

Everytime app start,
* a `preload` script file imported in main [webPreferences](https://electronjs.org/docs/api/browser-window#new-browserwindowoptions) is loaded before other scripts
* on `getName()` request, it publish to an async event using [ipcRenderer](https://electronjs.org/docs/api/ipc-renderer) subscribed in main process using [ipcMain](https://electronjs.org/docs/api/ipc-main)
* this subscription publish to another event the Electron app name
* back in the `preload` script in `getName()`, it also subscribe to the new publication and resolve the request with receiving data
* same for `getVersion()`

### Alternatives

My first try and fail was to think all is running in a single process, so I extended the `global` object with `window`.

## Critical analysis

### General feeling

I felt like coding in the dark ! Not because this is Javascript Vanilla, but the lack of time setting up debug methods. Restarting and killing my script on every code change. I found later [devtron](https://electronjs.org/devtron) that would be useful to debug event listeners and IPC monitoring.
It would be great to have the opportunity to show you a complete web app with a great dev environnent.

### Difficulties

I first tried extending `global` object with a `window` object in main script,  but I understood there are 2 running processes. 
Preload script seemed the only way to access `window` without using remote API.
Then I tried to find a way to share data between main and renderer processes, so I used IPC.

### Strengths and weaknesses

Weaknesses
* app name and version method should be cached in an object.
* `ipcMain` listeners could be merged in one with a common event name and the `arg` could be the key (name or version) that switch between senders.

Strengths
* `ipcRenderer` uses asynchronous method in a `Promise` that enable non-blocking operations for the client.
